### PR TITLE
Change jQuery to jquery to avoid casing error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
     ]
   },
   externals: {
-    'jquery': 'jQuery'
+    'jquery': 'jquery'
   },
   plugins: [
     new webpack.ProvidePlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,9 +41,6 @@ module.exports = {
       }
     ]
   },
-  externals: {
-    'jquery': 'jquery'
-  },
   plugins: [
     new webpack.ProvidePlugin({
       $: 'jquery',


### PR DESCRIPTION
### Description

Just change "jQuery" to jquery to avoid casing error with other libraries.

```
There are multiple modules with names that only differ in casing.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
....
``` 
ref: https://github.com/farbelous/bootstrap-colorpicker/issues/272

### Check list

Please fill this check list before submitting a pull request:

- [x] The build process has been run (`npm run build`) and does not contain any errors.
- [x] All tests are green after running `npm run test`.
- [x] New tests have been added or modified for the introduced changes.
- [x] New examples have been added for the newly introduced features.
- [x] All the examples are still working as expected compared to the [official website](https://farbelous.io/bootstrap-colorpicker).
- [x] This PR follows all other [`CONTRIBUTING.md`](.github/CONTRIBUTING.md#pull-requests) guidelines for Pull Requests.
