### PR TITLE
give a chance to define variables before @import

### DIFF
--- a/src/sass/colorpicker.scss
+++ b/src/sass/colorpicker.scss
@@ -1,8 +1,8 @@
 $outline-color: rgba(0, 0, 0, 0.2);
 $box-shadow-outline: 0 0 0 1px $outline-color;
-$bar-size-short: 16px;
-$base-margin: 6px;
-$columns: 6; // this affects the number of swatches per row and the width of the color picker, saturation, etc.
+$bar-size-short: 16px !default;
+$base-margin: 6px !default;
+$columns: 6 !default; // this affects the number of swatches per row and the width of the color picker, saturation, etc.
 $bar-size-large: ($bar-size-short * $columns) + ($base-margin * ($columns - 1));
 
 @mixin bgCheckerBox($size: 10px) {


### PR DESCRIPTION
Allow to define those variables before using @import directive in another scss file.

<!-- 

FILLING THIS TEMPLATE IS MANDATORY IN CASE YOU MODIFY THE SOURCE CODE.

Thank you for your contribution to bootstrap-colorpicker! Please replace {Please write here} with your description.
Please note that PRs not following this template may be potentially discarded if they are not clear enough.
-->

### Description

{Please write here}

### Check list

Please fill this check list before submitting a pull request:

- [ ] The build process has been run (`npm run build`) and does not contain any errors.
- [ ] All tests are green after running `npm run test`.
- [ ] New tests have been added or modified for the introduced changes.
- [ ] New examples have been added for the newly introduced features.
- [ ] All the examples are still working as expected compared to the [official website](https://farbelous.io/bootstrap-colorpicker).
- [ ] This PR follows all other [`CONTRIBUTING.md`](.github/CONTRIBUTING.md#pull-requests) guidelines for Pull Requests.
