### PR TITLE
Issue 272

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+.editorconfig
+docker-compose.yml

--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,5 @@ gulpfile.js_*
 webpack.config.js
 composer.json
 gulpfile.js
+/docker
+docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3"
+
+services:
+  node-builder-6:
+    image: node-builder:6
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      args:
+        NODE_VERSION: 6
+    environment:
+      NODE_ENV: production
+  node-builder-8:
+    image: node-builder:8
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      args:
+        NODE_VERSION: 8
+    environment:
+      NODE_ENV: production
+  node-builder-10:
+    image: node-builder:10
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      args:
+        NODE_VERSION: 10
+    environment:
+      NODE_ENV: production
+  node-builder-11:
+    image: node-builder:11
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      args:
+        NODE_VERSION: 11
+    environment:
+      NODE_ENV: production

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+ARG NODE_VERSION=11
+FROM node:${NODE_VERSION}-alpine
+
+ENV NODE_ENV production
+
+RUN apk --no-cache add \
+    g++ \
+    git \
+    make \
+    python
+
+COPY . /app
+
+WORKDIR /app
+
+RUN npm install --unsafe-perm --production=false && \
+    npm run build && \
+    npm run test && \
+    npm prune

--- a/src/js/AddonHandler.js
+++ b/src/js/AddonHandler.js
@@ -14,7 +14,7 @@ class AddonHandler {
      */
     this.colorpicker = colorpicker;
     /**
-     * @type {jQuery}
+     * @type {jquery}
      */
     this.addon = null;
   }
@@ -25,7 +25,7 @@ class AddonHandler {
 
   bind() {
     /**
-     * @type {*|jQuery}
+     * @type {*|jquery}
      */
     this.addon = this.colorpicker.options.addon ?
       this.colorpicker.element.find(this.colorpicker.options.addon) : null;

--- a/src/js/ColorItem.js
+++ b/src/js/ColorItem.js
@@ -99,7 +99,7 @@ class ColorItem {
    * @example color.replace(hsvaColorData);
    */
   replace(color, format = null) {
-    let fallback = null;
+    let fallback = '#000000';
 
     format = ColorItem.sanitizeFormat(format);
 

--- a/src/js/ColorItem.js
+++ b/src/js/ColorItem.js
@@ -99,7 +99,6 @@ class ColorItem {
    * @example color.replace(hsvaColorData);
    */
   replace(color, format = null) {
-    let fallback = '#000000';
 
     format = ColorItem.sanitizeFormat(format);
 
@@ -119,7 +118,7 @@ class ColorItem {
     this._color = ColorItem.parse(color);
 
     if (this._color === null) {
-      this._color = QixColor(fallback);
+      this._color = QixColor();
       this._original.valid = false;
       return;
     }

--- a/src/js/Colorpicker.js
+++ b/src/js/Colorpicker.js
@@ -60,7 +60,7 @@ class Colorpicker {
   /**
    * Getter of the picker element
    *
-   * @returns {jQuery|HTMLElement}
+   * @returns {jquery|HTMLElement}
    */
   get picker() {
     return this.pickerHandler.picker;
@@ -93,7 +93,7 @@ class Colorpicker {
     /**
      * The element that the colorpicker is bound to
      *
-     * @type {*|jQuery}
+     * @type {*|jquery}
      */
     this.element = $(element)
       .addClass('colorpicker-element')
@@ -119,7 +119,7 @@ class Colorpicker {
 
     /**
      * The element where the
-     * @type {*|jQuery}
+     * @type {*|jquery}
      */
     this.container = (
       this.options.container === true ||

--- a/src/js/InputHandler.js
+++ b/src/js/InputHandler.js
@@ -17,7 +17,7 @@ class InputHandler {
      */
     this.colorpicker = colorpicker;
     /**
-     * @type {jQuery|false}
+     * @type {jquery|false}
      */
     this.input = this.colorpicker.element.is('input') ? this.colorpicker.element : (this.colorpicker.options.input ?
       this.colorpicker.element.find(this.colorpicker.options.input) : false);

--- a/src/js/PickerHandler.js
+++ b/src/js/PickerHandler.js
@@ -16,7 +16,7 @@ class PickerHandler {
      */
     this.colorpicker = colorpicker;
     /**
-     * @type {jQuery}
+     * @type {jquery}
      */
     this.picker = null;
   }
@@ -31,7 +31,7 @@ class PickerHandler {
 
   bind() {
     /**
-     * @type {jQuery|HTMLElement}
+     * @type {jquery|HTMLElement}
      */
     let picker = this.picker = $(this.options.template);
 

--- a/src/js/PopupHandler.js
+++ b/src/js/PopupHandler.js
@@ -22,11 +22,11 @@ class PopupHandler {
      */
     this.colorpicker = colorpicker;
     /**
-     * @type {jQuery}
+     * @type {jquery}
      */
     this.popoverTarget = null;
     /**
-     * @type {jQuery}
+     * @type {jquery}
      */
     this.popoverTip = null;
 
@@ -47,7 +47,7 @@ class PopupHandler {
 
   /**
    * @private
-   * @returns {jQuery|false}
+   * @returns {jquery|false}
    */
   get input() {
     return this.colorpicker.inputHandler.input;
@@ -63,7 +63,7 @@ class PopupHandler {
 
   /**
    * @private
-   * @returns {jQuery|false}
+   * @returns {jquery|false}
    */
   get addon() {
     return this.colorpicker.addonHandler.addon;

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -7,7 +7,7 @@ let plugin = 'colorpicker';
 
 $[plugin] = Colorpicker;
 
-// Colorpicker jQuery Plugin API
+// Colorpicker jquery Plugin API
 $.fn[plugin] = function (option) {
   let fnArgs = Array.prototype.slice.call(arguments, 1),
     isSingleElement = (this.length === 1),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
     ]
   },
   externals: {
-    'jquery': 'jQuery'
+    'jquery': 'jquery'
   },
   plugins: [
     new webpack.ProvidePlugin({


### PR DESCRIPTION
### Description

1. Bundling color-picker with another jquery based lib, conduct to crash on webpack build cause `"There are multiple modules with names that only differ in casing"`
2. Fix test that were not passing on master.
3. Add a Docker image, that allow contributor to run a integration test before pushing code.

```bash
docker-compose build
```
It will build the library using node (v6, v8, v10, v11) and run tests, if all images are building without error, you can assume that it will pass *travis* without error.

This change is BC Break because of renaming the jquery alias (it could break on case sensitive systems).

### Check list

Please fill this check list before submitting a pull request:

- [x] The build process has been run (`npm run build`) and does not contain any errors.
- [x] All tests are green after running `npm run test`.
- [x] New tests have been added or modified for the introduced changes.
- [x] New examples have been added for the newly introduced features.
- [x] All the examples are still working as expected compared to the [official website](https://farbelous.io/bootstrap-colorpicker).
- [x] This PR follows all other [`CONTRIBUTING.md`](.github/CONTRIBUTING.md#pull-requests) guidelines for Pull Requests.